### PR TITLE
Add alignment tests

### DIFF
--- a/tests/testthat/helper-tibbles.R
+++ b/tests/testthat/helper-tibbles.R
@@ -1,0 +1,13 @@
+test_tibble_1 <- tibble::tribble(
+  ~Name,   ~Age, ~City,         ~Date,
+  "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
+  "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
+  "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
+)
+
+test_tibble_2 <- tibble::tribble(
+  ~Name,   ~Age, ~City,         ~Date,
+  "Alice", 30,   NA,            lubridate::ymd("2021/01/08"),
+  "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
+  "Carol", 27,   "Chicago",     NA
+)

--- a/tests/testthat/test-extract_md_tables.R
+++ b/tests/testthat/test-extract_md_tables.R
@@ -1,15 +1,7 @@
 test_that("extract_md_tables can read a markdown table from file", {
   md_file <- test_path("testmd", "simple.md")
   md_table <- extract_md_tables(md_file, show_col_types = FALSE)
-
-  expected_tibble <- tibble::tribble(
-    ~Name,   ~Age, ~City,         ~Date,
-    "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
-    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
-    "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
-  )
-
-  expect_identical(expected_tibble, md_table)
+  expect_identical(test_tibble_1, md_table)
 })
 
 
@@ -143,13 +135,5 @@ test_that("extract_md_tables can read multiple messy markdown tables from new fi
 test_that("extract_md_tables handles alignment separators", {
   md_file <- test_path("testmd", "aligned.md")
   md <- extract_md_tables(md_file, show_col_types = FALSE)
-
-  expected_tibble <- tibble::tribble(
-    ~Name,   ~Age, ~City,         ~Date,
-    "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
-    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
-    "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
-  )
-
-  expect_identical(expected_tibble, md)
+  expect_identical(test_tibble_1, md)
 })

--- a/tests/testthat/test-extract_md_tables.R
+++ b/tests/testthat/test-extract_md_tables.R
@@ -138,3 +138,18 @@ test_that("extract_md_tables can read multiple messy markdown tables from new fi
 
   expect_identical(table4, md_tables[[4]])
 })
+
+
+test_that("extract_md_tables handles alignment separators", {
+  md_file <- test_path("testmd", "aligned.md")
+  md <- extract_md_tables(md_file, show_col_types = FALSE)
+
+  expected_tibble <- tibble::tribble(
+    ~Name,   ~Age, ~City,         ~Date,
+    "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
+    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
+    "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
+  )
+
+  expect_identical(expected_tibble, md)
+})

--- a/tests/testthat/test-read_md_table.R
+++ b/tests/testthat/test-read_md_table.R
@@ -1,45 +1,21 @@
 test_that("read_md_table can read simple markdown table from file", {
   md_file <- test_path("testmd", "simple.md")
   md <- read_md_table(md_file, show_col_types = FALSE)
-
-  expected_tibble <- tibble::tribble(
-    ~Name,   ~Age, ~City,         ~Date,
-    "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
-    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
-    "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
-  )
-
-  expect_identical(expected_tibble, md)
+  expect_identical(test_tibble_1, md)
 })
 
 
 test_that("read_md_table can handle missing values in markdown table from file", {
   md_file <- test_path("testmd", "missing-values.md")
   md <- read_md_table(md_file, show_col_types = FALSE)
-
-  expected_tibble <- tibble::tribble(
-    ~Name,   ~Age, ~City,         ~Date,
-    "Alice", 30,   NA,            lubridate::ymd("2021/01/08"),
-    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
-    "Carol", 27,   "Chicago",     NA,
-  )
-
-  expect_identical(expected_tibble, md)
+  expect_identical(test_tibble_2, md)
 })
 
 
 test_that("read_md_table can read messy markdown table from file", {
   md_file <- test_path("testmd", "messy.md")
   md <- read_md_table(md_file, show_col_types = FALSE)
-
-  expected_tibble <- tibble::tribble(
-    ~Name,   ~Age, ~City,         ~Date,
-    "Alice", 30,   NA,            lubridate::ymd("2021/01/08"),
-    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
-    "Carol", 27,   "Chicago",     NA
-  )
-
-  expect_identical(expected_tibble, md)
+  expect_identical(test_tibble_2, md)
 })
 
 
@@ -47,15 +23,7 @@ test_that("read_md_table can read messy markdown table from string", {
   md_string <- I("| Name  | Age | City        | Date       |\n|-------|-----|-------------|------------|\n| Alice | 30  | New York    | 2021/01/08 |\n| Bob   | 25  | Los Angeles | 2023/07/22 |\n| Carol | 27  | Chicago     | 2022/11/01 |
 ")
   md <- read_md_table(md_string, show_col_types = FALSE)
-
-  expected_tibble <- tibble::tribble(
-    ~Name,   ~Age, ~City,         ~Date,
-    "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
-    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
-    "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
-  )
-
-  expect_identical(expected_tibble, md)
+  expect_identical(test_tibble_1, md)
 })
 
 
@@ -63,7 +31,6 @@ test_that("read_md_table can read a markdown table from URL", {
   mtcars <- "https://raw.githubusercontent.com/jrdnbradford/readMDTable/main/inst/extdata/mtcars.md"
   expected_tibble <- read_md_table(mtcars, show_col_types = FALSE)
   md <- read_md_table(read_md_table_example("mtcars.md"), show_col_types = FALSE)
-
   expect_identical(expected_tibble, md)
 })
 
@@ -109,28 +76,12 @@ test_that("read_md_table handles separator line format of Gutenberg Project's mi
   # https://www.gutenberg.org/MIRRORS.ALL
   md_file <- test_path("testmd", "gutenberg.md")
   md <- read_md_table(md_file, warn = FALSE, show_col_types = FALSE)
-
-  expected_tibble <- tibble::tribble(
-    ~Name,   ~Age, ~City,         ~Date,
-    "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
-    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
-    "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
-  )
-
-  expect_identical(expected_tibble, md)
+  expect_identical(test_tibble_1, md)
 })
 
 
 test_that("read_md_table handles alignment separators", {
   md_file <- test_path("testmd", "aligned.md")
   md <- read_md_table(md_file, show_col_types = FALSE)
-
-  expected_tibble <- tibble::tribble(
-    ~Name,   ~Age, ~City,         ~Date,
-    "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
-    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
-    "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
-  )
-
-  expect_identical(expected_tibble, md)
+  expect_identical(test_tibble_1, md)
 })

--- a/tests/testthat/test-read_md_table.R
+++ b/tests/testthat/test-read_md_table.R
@@ -119,3 +119,18 @@ test_that("read_md_table handles separator line format of Gutenberg Project's mi
 
   expect_identical(expected_tibble, md)
 })
+
+
+test_that("read_md_table handles alignment separators", {
+  md_file <- test_path("testmd", "aligned.md")
+  md <- read_md_table(md_file, show_col_types = FALSE)
+
+  expected_tibble <- tibble::tribble(
+    ~Name,   ~Age, ~City,         ~Date,
+    "Alice", 30,   "New York",    lubridate::ymd("2021/01/08"),
+    "Bob",   25,   "Los Angeles", lubridate::ymd("2023/07/22"),
+    "Carol", 27,   "Chicago",     lubridate::ymd("2022/11/01")
+  )
+
+  expect_identical(expected_tibble, md)
+})

--- a/tests/testthat/testmd/aligned.md
+++ b/tests/testthat/testmd/aligned.md
@@ -1,0 +1,5 @@
+| Name  | Age | City        | Date       |
+|-------|:---:|:------------|-----------:|
+| Alice | 30  | New York    | 2021/01/08 |
+| Bob   | 25  | Los Angeles | 2023/07/22 |
+| Carol | 27  | Chicago     | 2022/11/01 |


### PR DESCRIPTION
Adds tests to ensure the package can handle `:` in separator lines for alignment. Also abstracts some tables into `helper-variables.R`.