### PR TITLE
Make return value for `extract_md_tables` consistent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readMDTable (development version)
 
+* BREAKING CHANGE: `extract_md_tables` now always returns a named list of tibbles (names `"table_1"`, `"table_2"`, …) regardless of how many tables are found. Previously a single tibble was returned when only one table was present.
+
 # readMDTable 0.3.3
 
 * Update to {roxygen2} to 8.0.0

--- a/R/extract_md_tables.R
+++ b/R/extract_md_tables.R
@@ -1,13 +1,13 @@
 #' @title Extract Markdown Tables from Markdown Files
 #'
 #' @details `extract_md_tables` captures all the markdown tables
-#'   from `file` and returns a tibble or list of tibbles.
+#'   from `file` and returns a named list of tibbles.
 #'
 #' @inheritParams read_md_table
 #' @inheritDotParams readr::read_delim -trim_ws -delim
 #'
-#' @returns A tibble or list of tibbles extracted from the
-#'   markdown tables in `file`.
+#' @returns A named list of tibbles (names `"table_1"`, `"table_2"`, …)
+#'   extracted from the markdown tables in `file`.
 #'
 #' @examples
 #' md <-
@@ -91,10 +91,7 @@ extract_md_tables <- function(file, ...) {
     return(table_tibble$result)
   })
 
-  if (length(table_tibbles) == 1) {
-    return(table_tibbles[[1]])
-  }
-
+  names(table_tibbles) <- paste0("table_", seq_along(table_tibbles))
   return(table_tibbles)
 }
 

--- a/man/extract_md_tables.Rd
+++ b/man/extract_md_tables.Rd
@@ -146,15 +146,15 @@ Learn more in \code{\link[readr:should_read_lazy]{should_read_lazy()}} and in th
   }}
 }
 \value{
-A tibble or list of tibbles extracted from the
-markdown tables in \code{file}.
+A named list of tibbles (names \code{"table_1"}, \code{"table_2"}, …)
+extracted from the markdown tables in \code{file}.
 }
 \description{
 Extract Markdown Tables from Markdown Files
 }
 \details{
 \code{extract_md_tables} captures all the markdown tables
-from \code{file} and returns a tibble or list of tibbles.
+from \code{file} and returns a named list of tibbles.
 }
 \examples{
 md <-

--- a/tests/testthat/test-extract_md_tables.R
+++ b/tests/testthat/test-extract_md_tables.R
@@ -1,7 +1,11 @@
 test_that("extract_md_tables can read a markdown table from file", {
   md_file <- test_path("testmd", "simple.md")
   md_table <- extract_md_tables(md_file, show_col_types = FALSE)
-  expect_identical(test_tibble_1, md_table)
+  expect_length(md_table, 1)
+  expect_true(inherits(md_table, "list"))
+  expect_named(md_table, "table_1")
+  expect_identical(test_tibble_1, md_table[[1]])
+  expect_identical(test_tibble_1, md_table[["table_1"]])
 })
 
 
@@ -10,6 +14,7 @@ test_that("extract_md_tables can read multiple markdown tables from simple file"
   md_tables <- extract_md_tables(md_file, show_col_types = FALSE)
   expect_length(md_tables, 4)
   expect_true(inherits(md_tables, "list"))
+  expect_named(md_tables, paste0("table_", 1:4))
 
   table1 <- tibble::tribble(
     ~model,          ~mpg, ~cyl, ~disp, ~hp,  ~drat, ~wt,    ~qsec, ~vs, ~am, ~gear, ~carb,
@@ -68,11 +73,13 @@ test_that("extract_md_tables can read multiple markdown tables from simple file"
   expect_identical(table4, md_tables[[4]])
 })
 
+
 test_that("extract_md_tables can read multiple messy markdown tables from new file", {
   md_file <- test_path("testmd", "messy-multiple-tables.md")
   md_tables <- extract_md_tables(md_file, show_col_types = FALSE)
   expect_length(md_tables, 4)
   expect_true(inherits(md_tables, "list"))
+  expect_named(md_tables, paste0("table_", 1:4))
 
   table1 <- tibble::tribble(
     ~model,           ~mpg, ~cyl, ~disp, ~hp,  ~drat, ~wt,    ~qsec, ~vs, ~am, ~gear, ~carb, ~date,
@@ -135,16 +142,21 @@ test_that("extract_md_tables can read multiple messy markdown tables from new fi
 test_that("extract_md_tables handles alignment separators", {
   md_file <- test_path("testmd", "aligned.md")
   md <- extract_md_tables(md_file, show_col_types = FALSE)
-  expect_identical(test_tibble_1, md)
+  expect_length(md, 1)
+  expect_true(inherits(md, "list"))
+  expect_named(md, "table_1")
+  expect_identical(test_tibble_1, md[[1]])
+  expect_identical(test_tibble_1, md[["table_1"]])
 })
 
 
 test_that("extract_md_tables can handle complicated Terraform READMEs", {
   md_file <- test_path("testmd", "gke-terraform.md")
   md <- extract_md_tables(md_file, show_col_types = FALSE)
-  expect_identical(tf_tibble_1, md[[1]])
-  expect_identical(tf_tibble_2, md[[2]])
-  expect_identical(tf_tibble_3, md[[3]])
+  expect_named(md, paste0("table_", 1:3))
+  expect_identical(tf_tibble_1, md[["table_1"]])
+  expect_identical(tf_tibble_2, md[["table_2"]])
+  expect_identical(tf_tibble_3, md[["table_3"]])
 })
 
 


### PR DESCRIPTION
Currently it returns a `tibble` if there is one table and a list of `tibble`s if more. This makes the value a named list.